### PR TITLE
Update CHANGELOG.md and visit-observation-service.js to fix observati…

### DIFF
--- a/db/app2/public/CHANGELOG.md
+++ b/db/app2/public/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+- [2025-12-19] Fixed observation creation from questionnaires failing with "No patient selected" error - now allows observation creation when PATIENT_NUM is explicitly provided, even without a selected patient in the store
+- [2025-12-19] Fixed observations not appearing immediately on PatientPage after questionnaire submission - modified visit-observation-service to always reload observations when loading patient data, ensuring fresh data is displayed
 - [2025-12-18] Fixed questionnaire submission error when auto-creating visits - now uses visit repository which properly handles `lastInsertRowid` being undefined in Electron environment
 - [2025-12-18] Fixed Vue prop type warning for `completionDate` in questionnaire preview - now properly converts number timestamps to ISO string format
 - [2025-12-18] Fixed questionnaire submission summary showing "0 Questions Answered" - now correctly displays `items.length` and shows detailed counts including answers added as separate observations

--- a/db/app2/src/services/visit-observation-service.js
+++ b/db/app2/src/services/visit-observation-service.js
@@ -49,18 +49,20 @@ class VisitObservationService {
 
       const { patient, isNewPatient } = result
 
-      // Only load visits if it's a new patient selection
+      // Always reload visits and observations to ensure we have the latest data
+      // This is especially important after questionnaire submissions or other operations
+      // that create new observations
       if (isNewPatient) {
-        // Clear previous data
+        // Clear previous data only for new patients
         visitStore.clearVisits()
         observationStore.clearAllObservations()
-
-        // Load visits for the patient
-        await visitStore.loadVisitsForPatient(patient.PATIENT_NUM)
-
-        // Load all observations for the patient
-        await observationStore.loadAllObservationsForPatient(patient.PATIENT_NUM)
       }
+
+      // Load visits for the patient (always, to get fresh data)
+      await visitStore.loadVisitsForPatient(patient.PATIENT_NUM)
+
+      // Load all observations for the patient (always, to get fresh data)
+      await observationStore.loadAllObservationsForPatient(patient.PATIENT_NUM)
 
       this.logger.success('Patient data loaded successfully', {
         patientCode,
@@ -279,12 +281,14 @@ class VisitObservationService {
       const visitStore = useVisitStore()
       const observationStore = useObservationStore()
 
-      if (!patientStore.hasPatient) {
+      // Allow creating observations if PATIENT_NUM is explicitly provided (e.g., from questionnaire)
+      // Otherwise, require a selected patient in the store
+      if (!observationData.PATIENT_NUM && !patientStore.hasPatient) {
         throw new Error('No patient selected')
       }
 
-      // Ensure patient number is included
-      observationData.PATIENT_NUM = patientStore.patientNum
+      // Ensure patient number is included - use provided value or get from store
+      observationData.PATIENT_NUM = observationData.PATIENT_NUM || patientStore.patientNum
 
       this.logger.info('Creating observation', {
         conceptCode: observationData.CONCEPT_CD,


### PR DESCRIPTION
…on creation and data loading issues

- Fixed observation creation from questionnaires to allow explicit PATIENT_NUM without a selected patient.
- Ensured observations reload immediately on PatientPage after questionnaire submission by always fetching fresh data.